### PR TITLE
Fix shebang

### DIFF
--- a/exe/jumon
+++ b/exe/jumon
@@ -1,6 +1,5 @@
+#!/usr/bin/env ruby
 # frozen_string_literal: true
-
-# !/usr/bin/env ruby
 
 require 'openai'
 require 'jumon'


### PR DESCRIPTION
- it needs to be the first line
- no spaces between `#` and `!`

Without this, you get errors running `exe/jumon`. It also doesn't correctly get syntax highlighting in most editors.